### PR TITLE
Update deployment apiVersion

### DIFF
--- a/templates/dittybopper.yaml.template
+++ b/templates/dittybopper.yaml.template
@@ -28,7 +28,7 @@ spec:
   port:
     targetPort: 3000
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
According to K8S docs, Deployments in the extensions/v1beta1 API version are not longer supported.
Migrate it to apps/v1

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/