### PR TITLE
Fix Grafana Version

### DIFF
--- a/templates/dittybopper.yaml.template
+++ b/templates/dittybopper.yaml.template
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: dittybopper
-        image: docker.io/grafana/grafana:master
+        image: docker.io/grafana/grafana:6.7.2
         ports:
         - name: sc-grafana-http
           containerPort: 3000


### PR DESCRIPTION
removing the `:master` tag and switching to `:6.7.2`. This will help
ensure consistency of the UI.